### PR TITLE
SplitN(..,1) results always in 1 part; really need 2 parts to get the channel key or other options

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -284,7 +284,7 @@ func (s *Server) handle(c *girc.Client, e *Event) {
 
 func (s *Server) onConnect(c *girc.Client, e girc.Event) {
 	for i := 0; i < len(s.Channels); i++ {
-		if split := strings.SplitN(s.Channels[i], " ", 1); len(split) == 2 {
+		if split := strings.SplitN(s.Channels[i], " ", 2); len(split) == 2 {
 			c.Cmd.JoinKey(split[0], split[1])
 			continue
 		}


### PR DESCRIPTION
Passworded channels do not work, as SplitN(..,1) results always in 1 part; really need 2 parts to get the channel key or other options.

Thus changing that 1 into a 2 solves it as then it returns 2 parts.


Also, as it has been a while, please publish new packages, the new library is much better.

Do check your dependencies, the ones for 'make build' are huge, many are likely not needed.
But, that is likely because it is 3 years ago that the last commit was made.

Greets,
 Jeroen
